### PR TITLE
텍스트 컴포넌트 구현 및 storybook 연동

### DIFF
--- a/src/components/common/icon/index.tsx
+++ b/src/components/common/icon/index.tsx
@@ -1,9 +1,10 @@
 import { CSSProperties } from 'react';
+import * as style from './style.css';
 
-type IconProps = {
+export type IconProps = {
   type?: 'light' | 'regular' | 'solid' | 'thin';
   name?: string;
-  size?: number;
+  size?: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
   color?: string;
   style?: CSSProperties;
 };
@@ -12,7 +13,7 @@ type IconProps = {
  * Font-awesome Icon Component
  * @param {'light' | 'regular' | 'solid' | 'thin'} type - Icon type(default: solid)
  * @param {string} name - Icon name(default: xmark)
- * @param {number} size - Icon size(default: 1.0)
+ * @param {string} size - Icon size(default: medium(1.4rem)) expected to be one of ['xSmall', 'small', 'medium', 'large', 'xLarge']
  * @param {string} color - Icon color(default: #9a9a9a)
  * @returns {Icon} Font-awesome icon
  */
@@ -20,14 +21,14 @@ type IconProps = {
 const Icon = ({
   type = 'solid',
   name = 'xmark',
-  size = 1.0,
+  size = 'medium',
   color = '#9a9a9a',
   ...props
 }: IconProps) => {
   return (
     <i
-      className={`fa-${type} fa-${name} ${name}`}
-      style={{ fontSize: `${size}rem`, color, ...props.style }}
+      className={`fa-${type} fa-${name} ${name} ${style.icon({ size })}`}
+      style={{ color, ...props.style }}
       {...props}
     ></i>
   );

--- a/src/components/common/icon/style.css.ts
+++ b/src/components/common/icon/style.css.ts
@@ -1,0 +1,14 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@/styles/variants.css';
+
+export const icon = recipe({
+  variants: {
+    size: {
+      xSmall: { fontSize: vars.fontSize.xSmall },
+      small: { fontSize: vars.fontSize.small },
+      medium: { fontSize: vars.fontSize.medium },
+      large: { fontSize: vars.fontSize.large },
+      xLarge: { fontSize: vars.fontSize.xLarge },
+    },
+  },
+});

--- a/src/components/common/text/index.tsx
+++ b/src/components/common/text/index.tsx
@@ -6,7 +6,7 @@ export type TextProps = {
   block?: boolean;
   paragraph?: boolean;
   size?: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
-  weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+  weight?: 300 | 400 | 500 | 600 | 700 | 800;
   underline?: boolean;
   color?: string;
   style?: CSSProperties;

--- a/src/components/common/text/index.tsx
+++ b/src/components/common/text/index.tsx
@@ -1,5 +1,54 @@
-const Text = () => {
-  return <div></div>;
+import { CSSProperties, ReactNode } from 'react';
+import * as style from './style.css';
+
+export type TextProps = {
+  children: ReactNode;
+  block?: boolean;
+  paragraph?: boolean;
+  size?: 'xSmall' | 'small' | 'medium' | 'large' | 'xLarge';
+  weight?: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
+  underline?: boolean;
+  color?: string;
+  style?: CSSProperties;
+};
+
+/**
+ * Text Component
+ * @param {boolean} block - if block, tag is set to div
+ * @param {boolean} paragraph - if paragraph, tag is set to p / if neither block nor paragraph, tag is set to span
+ * @param {boolean} underline - if underline, text's decoration is set to underline
+ * @param {union} size - text size (default: medium(1.6rem)) expected to be one of ['xSmall' | 'small' | 'medium' | 'large' | 'xLarge']
+ * @param {union} weight - text's font weight
+ * @param {string} color - text color
+ * @returns {Text} Text Component
+ */
+
+const Text = ({
+  children,
+  block,
+  paragraph,
+  size = 'medium',
+  weight = 400,
+  underline,
+  color,
+  ...props
+}: TextProps) => {
+  const Tag = block ? 'div' : paragraph ? 'p' : 'span';
+  const fontStyle = {
+    textDecoration: underline ? 'underline' : undefined,
+    textUnderlinePosition: underline ? 'under' : undefined,
+    color,
+  };
+
+  return (
+    <Tag
+      className={style.text({ size, weight })}
+      style={{ ...fontStyle, ...props.style }}
+      {...props}
+    >
+      {children}
+    </Tag>
+  );
 };
 
 export default Text;

--- a/src/components/common/text/style.css.ts
+++ b/src/components/common/text/style.css.ts
@@ -1,0 +1,25 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@/styles/variants.css';
+
+export const text = recipe({
+  variants: {
+    size: {
+      xSmall: { fontSize: vars.fontSize.xSmall },
+      small: { fontSize: vars.fontSize.small },
+      medium: { fontSize: vars.fontSize.medium },
+      large: { fontSize: vars.fontSize.large },
+      xLarge: { fontSize: vars.fontSize.xLarge },
+    },
+    weight: {
+      100: { fontWeight: 100 },
+      200: { fontWeight: 200 },
+      300: { fontWeight: 300 },
+      400: { fontWeight: 400 },
+      500: { fontWeight: 500 },
+      600: { fontWeight: 600 },
+      700: { fontWeight: 700 },
+      800: { fontWeight: 800 },
+      900: { fontWeight: 900 },
+    },
+  },
+});

--- a/src/components/common/text/style.css.ts
+++ b/src/components/common/text/style.css.ts
@@ -11,15 +11,12 @@ export const text = recipe({
       xLarge: { fontSize: vars.fontSize.xLarge },
     },
     weight: {
-      100: { fontWeight: 100 },
-      200: { fontWeight: 200 },
       300: { fontWeight: 300 },
       400: { fontWeight: 400 },
       500: { fontWeight: 500 },
       600: { fontWeight: 600 },
       700: { fontWeight: 700 },
       800: { fontWeight: 800 },
-      900: { fontWeight: 900 },
     },
   },
 });

--- a/src/stories/components/common/Icon.stories.tsx
+++ b/src/stories/components/common/Icon.stories.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@/components/common';
-import { CSSProperties } from 'react';
+import { IconProps } from '@/components/common/icon';
 
 export default {
   title: 'Components/Icon',
@@ -17,9 +17,9 @@ export default {
       description: 'icon name',
     },
     size: {
-      defaultValue: 1.0,
-      control: { type: 'number', min: 0.4, max: 30.0, step: 0.1 },
-      type: 'number',
+      defaultValue: 'medium',
+      control: 'inline-radio',
+      options: ['xSmall', 'small', 'medium', 'large', 'xLarge'],
       description: 'icon size',
     },
     color: {
@@ -31,14 +31,6 @@ export default {
   },
 };
 
-export const Default = (
-  args: JSX.IntrinsicAttributes & {
-    type?: 'light' | 'regular' | 'solid' | 'thin';
-    name?: string;
-    size?: number;
-    color?: string;
-    style?: CSSProperties;
-  }
-) => {
+export const Default = (args: IconProps) => {
   return <Icon {...args} />;
 };

--- a/src/stories/components/common/Text.stories.tsx
+++ b/src/stories/components/common/Text.stories.tsx
@@ -1,0 +1,39 @@
+import { Text } from '@/components/common';
+import { TextProps } from '@/components/common/text';
+
+export default {
+  title: 'Components/Text',
+  component: Text,
+  argTypes: {
+    block: {
+      defaultValue: false,
+      type: 'boolean',
+    },
+    paragraph: {
+      defaultValue: false,
+      type: 'boolean',
+    },
+    size: {
+      defaultValue: 'medium',
+      control: 'inline-radio',
+      options: ['xSmall', 'small', 'medium', 'large', 'xLarge'],
+      description: 'text size',
+    },
+    weight: {
+      defaultValue: 400,
+      control: 'inline-radio',
+      options: [100, 200, 300, 400, 500, 600, 700, 800, 900],
+      description: 'text weight',
+    },
+    color: {
+      defaultValue: '#9a9a9a',
+      control: 'color',
+      type: 'string',
+      description: 'text color',
+    },
+  },
+};
+
+export const Default = (args: TextProps) => {
+  return <Text {...args}>Text test</Text>;
+};

--- a/src/stories/components/common/Text.stories.tsx
+++ b/src/stories/components/common/Text.stories.tsx
@@ -22,7 +22,7 @@ export default {
     weight: {
       defaultValue: 400,
       control: 'inline-radio',
-      options: [100, 200, 300, 400, 500, 600, 700, 800, 900],
+      options: [300, 400, 500, 600, 700, 800],
       description: 'text weight',
     },
     color: {

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -4,7 +4,6 @@ import { globalStyle } from '@vanilla-extract/css';
 globalStyle('*, *:after, *:before', {
   boxSizing: 'border-box',
   fontSize: '100%',
-  font: 'inherit',
 });
 
 globalStyle('html', {
@@ -22,7 +21,7 @@ globalStyle('body', {
 });
 
 globalStyle(
-  'html, body, div, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, em, img, ins, kbd, q, s, samp, small, strike, strong, article, footer, header, main, nav, section',
+  'html, body, div, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, em, img, ins, kbd, q, s, samp, small, span, strike, strong, article, footer, header, main, nav, section',
   {
     margin: 0,
     padding: 0,

--- a/src/styles/variants.css.ts
+++ b/src/styles/variants.css.ts
@@ -16,9 +16,11 @@ export const vars = createGlobalTheme(':root', {
     },
   },
   fontSize: {
-    small: '1.2rem',
-    medium: '1.4rem',
+    xSmall: '1.2rem',
+    small: '1.4rem',
+    medium: '1.6rem',
     large: '1.8rem',
+    xLarge: '2.3rem',
   },
   space: {
     xSmall: '1rem',


### PR DESCRIPTION
## 💡 이슈 번호
close #12 

## 📖 작업 내용
- [x] 텍스트 컴포넌트 구현
- [x] storybook 연동
- [x] 아이콘 컴포넌트 리팩터

## ✅ PR 포인트
- text weight 부분 key, value가 같아서 깔끔하게 짤 수 있을 것 같은데 당장은 어떻게 하는지 모르겠네요 ;ㅠ

## 📸 스크린샷
<img width="820" alt="스크린샷 2023-02-21 오후 3 02 19" src="https://user-images.githubusercontent.com/34560965/220260524-d71764e9-fd5c-4534-9927-bb9d1837deca.png">
