### PR TITLE
뱃지 컴포넌트 구현 및 storybook 연동

### DIFF
--- a/.storybook/preview.cjs
+++ b/.storybook/preview.cjs
@@ -1,4 +1,5 @@
 import '@fortawesome/fontawesome-free/css/all.css';
+import '@/styles/global.css';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/src/components/common/avatar/style.css.ts
+++ b/src/components/common/avatar/style.css.ts
@@ -1,12 +1,13 @@
+import * as utils from '@/styles/utils.css';
 import { recipe } from '@vanilla-extract/recipes';
 
 export const avatar = recipe({
-  base: {
-    display: 'inline-block',
-    position: 'relative',
-    overflow: 'hidden',
-    borderRadius: '50%',
-  },
+  base: [
+    { display: 'inline-block' },
+    utils.positionRelative,
+    utils.overflowHidden,
+    utils.borderRadiusRound,
+  ],
 
   variants: {
     size: {
@@ -16,9 +17,9 @@ export const avatar = recipe({
       xLarge: { width: '15rem', height: '15rem' },
     },
     shape: {
-      circle: { borderRadius: '50%' },
-      round: { borderRadius: '1rem' },
-      square: { borderRadius: 0 },
+      circle: [utils.borderRadiusRound],
+      round: [utils.borderRadius],
+      square: [utils.borderNone],
     },
   },
 });

--- a/src/components/common/badge/index.tsx
+++ b/src/components/common/badge/index.tsx
@@ -1,28 +1,30 @@
 import * as style from './style.css';
 
 export type BadgeProps = {
-  text: boolean;
+  isText: boolean;
 };
 
 // header AlramIcon badge, 알람 모달 badge / 데일리 브리핑 new badge
-const Badge = ({ text }: BadgeProps) => {
-  return text ? (
-    <div
-      className={style.badge({
-        size: 'text',
-        borderRadius: 'text',
-        display: 'flex',
-      })}
-    >
-      new
+const Badge = ({ isText }: BadgeProps) => {
+  return (
+    <div className={style.badgeContainer}>
+      <div
+        className={style.badge(
+          isText
+            ? {
+                size: 'text',
+                borderRadius: 'text',
+                display: 'flex',
+              }
+            : {
+                size: 'circle',
+                borderRadius: 'circle',
+              }
+        )}
+      >
+        {isText && 'new'}
+      </div>
     </div>
-  ) : (
-    <div
-      className={style.badge({
-        size: 'circle',
-        borderRadius: 'circle',
-      })}
-    />
   );
 };
 

--- a/src/components/common/badge/index.tsx
+++ b/src/components/common/badge/index.tsx
@@ -1,16 +1,16 @@
 import * as style from './style.css';
 
 export type BadgeProps = {
-  isText: boolean;
+  hasText: boolean;
 };
 
 // header AlramIcon badge, 알람 모달 badge / 데일리 브리핑 new badge
-const Badge = ({ isText }: BadgeProps) => {
+const Badge = ({ hasText }: BadgeProps) => {
   return (
     <div className={style.badgeContainer}>
       <div
         className={style.badge(
-          isText
+          hasText
             ? {
                 size: 'text',
                 borderRadius: 'text',
@@ -22,7 +22,7 @@ const Badge = ({ isText }: BadgeProps) => {
               }
         )}
       >
-        {isText && 'new'}
+        {hasText && 'new'}
       </div>
     </div>
   );

--- a/src/components/common/badge/index.tsx
+++ b/src/components/common/badge/index.tsx
@@ -1,5 +1,29 @@
-const Badge = () => {
-  return <div></div>;
+import * as style from './style.css';
+
+export type BadgeProps = {
+  text: boolean;
+};
+
+// header AlramIcon badge, 알람 모달 badge / 데일리 브리핑 new badge
+const Badge = ({ text }: BadgeProps) => {
+  return text ? (
+    <div
+      className={style.badge({
+        size: 'text',
+        borderRadius: 'text',
+        display: 'flex',
+      })}
+    >
+      new
+    </div>
+  ) : (
+    <div
+      className={style.badge({
+        size: 'circle',
+        borderRadius: 'circle',
+      })}
+    />
+  );
 };
 
 export default Badge;

--- a/src/components/common/badge/style.css.ts
+++ b/src/components/common/badge/style.css.ts
@@ -1,0 +1,30 @@
+import * as utils from '@/styles/utils.css';
+import * as variants from '@/styles/variants.css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const badge = recipe({
+  base: [
+    { backgroundColor: variants.vars.color.primary },
+    { color: 'white' },
+    utils.positionAbsolute,
+    utils.overflowHidden,
+  ],
+  variants: {
+    size: {
+      circle: { width: '0.75rem', height: '0.75rem' },
+      text: {
+        width: '2.4rem',
+        height: '1.2rem',
+        padding: '0.7rem 1.4rem',
+        fontWeight: 600,
+      },
+    },
+    borderRadius: {
+      circle: utils.borderRadiusRound,
+      text: utils.borderRadius,
+    },
+    display: {
+      flex: utils.flexCenter,
+    },
+  },
+});

--- a/src/components/common/badge/style.css.ts
+++ b/src/components/common/badge/style.css.ts
@@ -1,6 +1,12 @@
 import * as utils from '@/styles/utils.css';
 import * as variants from '@/styles/variants.css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+
+export const badgeContainer = style({
+  position: 'relative',
+  display: 'inline-block',
+});
 
 export const badge = recipe({
   base: [
@@ -13,9 +19,10 @@ export const badge = recipe({
     size: {
       circle: { width: '0.75rem', height: '0.75rem' },
       text: {
-        width: '2.4rem',
-        height: '1.2rem',
-        padding: '0.7rem 1.4rem',
+        height: '2rem',
+        padding: '0 0.8rem',
+        textAlign: 'center',
+        fontSize: variants.vars.fontSize.small,
         fontWeight: 600,
       },
     },
@@ -24,7 +31,7 @@ export const badge = recipe({
       text: utils.borderRadius,
     },
     display: {
-      flex: utils.flexCenter,
+      flex: utils.inlineFlex,
     },
   },
 });

--- a/src/stories/components/common/Badge.stories.tsx
+++ b/src/stories/components/common/Badge.stories.tsx
@@ -5,7 +5,7 @@ export default {
   title: 'Components/Badge',
   component: Badge,
   argTypes: {
-    isText: {
+    hasText: {
       defaultValue: true,
       control: 'inline-radio',
       options: [true, false],

--- a/src/stories/components/common/Badge.stories.tsx
+++ b/src/stories/components/common/Badge.stories.tsx
@@ -1,0 +1,18 @@
+import { Badge } from '@/components/common';
+import { BadgeProps } from '@/components/common/badge';
+
+export default {
+  title: 'Components/Badge',
+  component: Badge,
+  argTypes: {
+    text: {
+      defaultValue: true,
+      control: 'inline-radio',
+      options: [true, false],
+    },
+  },
+};
+
+export const Default = (args: BadgeProps) => {
+  return <Badge {...args} />;
+};

--- a/src/stories/components/common/Badge.stories.tsx
+++ b/src/stories/components/common/Badge.stories.tsx
@@ -5,7 +5,7 @@ export default {
   title: 'Components/Badge',
   component: Badge,
   argTypes: {
-    text: {
+    isText: {
       defaultValue: true,
       control: 'inline-radio',
       options: [true, false],


### PR DESCRIPTION
## 💡 이슈 번호
close #11 

## 📖 작업 내용
- [x] 뱃지 컴포넌트 구현
- [x] storybook 연동

## ✅ PR 포인트
- text를 display: flex, justify-content: center, align-items: center 해도 가운데 아닌거 같은데 크기가 너무 작아서 그런 걸까요?
- 현재는 text가 new만 받아서 이렇게 처리했는데 나중에 숫자 값이 들어오면 코드를 수정해야겠습니다.

## 📸 스크린샷
- text badge
![image](https://user-images.githubusercontent.com/60571418/220293675-486af417-c975-44a8-bace-ddc4f1ab6b59.png)
- 변경 후
![image](https://user-images.githubusercontent.com/60571418/220366643-ccd79e1d-ddee-458e-bd0a-234743df2278.png)

- dot badge
![image](https://user-images.githubusercontent.com/60571418/220293933-0a00c821-b76e-4296-9a78-8404c1a9fc39.png)

