### PR TITLE
divider 컴포넌트 구현 및 storybook 연동

### DIFF
--- a/src/components/common/divider/index.tsx
+++ b/src/components/common/divider/index.tsx
@@ -1,5 +1,11 @@
-const Divider = () => {
-  return <div></div>;
+import * as style from './style.css';
+
+export type DividerProps = {
+  type?: 'horizontal' | 'vertical';
+};
+
+const Divider = ({ type = 'horizontal' }: DividerProps) => {
+  return <hr className={style.divider({ type })} />;
 };
 
 export default Divider;

--- a/src/components/common/divider/style.css.ts
+++ b/src/components/common/divider/style.css.ts
@@ -1,0 +1,19 @@
+import { recipe } from '@vanilla-extract/recipes';
+import { vars } from '@/styles/variants.css';
+
+export const divider = recipe({
+  base: {
+    borderTop: `1px solid ${vars.color.border}`,
+  },
+  variants: {
+    type: {
+      horizontal: { display: 'block', margin: '2.2rem 0' },
+      vertical: {
+        display: 'inline-block',
+        width: '1.2rem',
+        margin: '0.8rem 0',
+        transform: 'rotate(90deg)',
+      },
+    },
+  },
+});

--- a/src/stories/components/common/Divider.stories.tsx
+++ b/src/stories/components/common/Divider.stories.tsx
@@ -1,0 +1,19 @@
+import { Divider } from '@/components/common';
+import { DividerProps } from '@/components/common/divider';
+
+export default {
+  title: 'Components/Divider',
+  component: Divider,
+  argTypes: {
+    type: {
+      defaultValue: 'horizontal',
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+      description: 'divider type',
+    },
+  },
+};
+
+export const Default = (args: DividerProps) => {
+  return <Divider {...args} />;
+};


### PR DESCRIPTION
## 💡 이슈 번호
close #20 

## 📖 작업 내용
- [x] divider 컴포넌트 구현 - horizontal, vertical
- [x] storybook 연동

## ✅ PR 포인트
horizontal, vertical 버전 모두 margin 값 변동 사항이 없을 것 같아 디자인 시안에서의 각 margin 값으로 고정해두었습니다.

## 📸 스크린샷
<img width='85%' src='https://user-images.githubusercontent.com/76807107/220376627-72d5a957-89b1-41be-940b-d5bf598750f8.png'/>
<img width='85%' src='https://user-images.githubusercontent.com/76807107/220376802-6a3cd64b-339e-49b0-b8e7-6c4cdba44370.png'/>