### PR TITLE
크리에이터, 아티클 카드 UI 구현

### DIFF
--- a/src/components/cardItem/article/CardBottom.css.ts
+++ b/src/components/cardItem/article/CardBottom.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import * as utils from '@/styles/utils.css';
 import { vars } from '@/styles/variants.css';
 
-export const CardBackgroundDim = style([
+export const cardBackgroundDim = style([
   utils.positionAbsolute,
   utils.borderRadius,
   utils.fullSize,
@@ -16,23 +16,23 @@ export const CardBackgroundDim = style([
   },
 ]);
 
-export const CardBottom = style([
+export const cardBottom = style([
   utils.flexColumn,
+  utils.fullHeight,
   {
     padding: '1.6rem',
-    height: '100%',
   },
 ]);
 
-export const BottomContent = style({
+export const bottomContent = style({
   flexGrow: 1,
 });
 
-export const BottomInfo = style([
+export const bottomInfo = style([
   utils.positionRelative,
   utils.flexAlignCenter,
   {
-    fontSize: '1.4rem',
+    fontSize: vars.fontSize.small,
     justifyContent: 'space-between',
     padding: 0,
     gap: '0.8rem',
@@ -41,33 +41,33 @@ export const BottomInfo = style([
     fontWeight: 700,
   },
 ]);
-export const BottomInfoCreater = style({
+export const bottomInfoCreater = style({
   ':hover': {
     cursor: 'pointer',
     color: 'black',
     textDecoration: 'underline',
   },
 });
-export const BottomEllipsis = style({
+export const bottomEllipsis = style({
   padding: '0.2rem',
   ':hover': {
     cursor: 'pointer',
     color: 'black',
   },
 });
-export const NotRecommanded = style([
+export const notRecommended = style([
   utils.flex,
   utils.textAlignCenter,
+  utils.cursorPointer,
   {
-    cursor: 'pointer',
-    padding: '2px 4px',
-    borderRadius: '5px',
+    padding: '0.2rem 0.4rem',
+    borderRadius: '0.5rem',
     ':hover': {
       backgroundColor: 'lightgray',
     },
   },
 ]);
-export const BottomTitle = style([
+export const bottomTitle = style([
   utils.textOverflowEllipsis,
   utils.overflowHidden,
   {
@@ -86,22 +86,22 @@ export const BottomTitle = style([
   },
 ]);
 
-export const BottomCompany = style([
+export const companyBanner = style([
   utils.flex,
   {
     padding: '1.2rem 1.6rem',
     gap: '1.6rem',
     height: '6rem',
     background: 'rgba(55,114,255,0.2)',
-    border: '2px solid rgba(55,114,255,0.12)',
+    border: '0.2rem solid rgba(55,114,255,0.12)',
     borderRadius: '1.2rem',
   },
 ]);
-export const CompanyName = style({
+export const companyName = style({
   fontWeight: 600,
   fontSize: vars.fontSize.small,
 });
-export const CompanyText = style({
+export const companyText = style({
   fontWeight: 600,
   fontSize: vars.fontSize.xSmall,
   color: 'rgba(42,40,47,0.8)',

--- a/src/components/cardItem/article/CardBottom.css.ts
+++ b/src/components/cardItem/article/CardBottom.css.ts
@@ -1,0 +1,106 @@
+import { style } from '@vanilla-extract/css';
+import * as utils from '@/styles/utils.css';
+import { vars } from '@/styles/variants.css';
+
+export const CardBackgroundDim = style([
+  utils.positionAbsolute,
+  utils.borderRadius,
+  utils.fullSize,
+  utils.top0,
+  utils.left0,
+  utils.overflowHidden,
+  {
+    cursor: 'default',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    zIndex: '1000',
+  },
+]);
+
+export const CardBottom = style([
+  utils.flexColumn,
+  {
+    padding: '1.6rem',
+    height: '100%',
+  },
+]);
+
+export const BottomContent = style({
+  flexGrow: 1,
+});
+
+export const BottomInfo = style([
+  utils.positionRelative,
+  utils.flexAlignCenter,
+  {
+    fontSize: '1.4rem',
+    justifyContent: 'space-between',
+    padding: 0,
+    gap: '0.8rem',
+    marginBottom: '1.2rem',
+    color: vars.color.font.secondary,
+    fontWeight: 700,
+  },
+]);
+export const BottomInfoCreater = style({
+  ':hover': {
+    cursor: 'pointer',
+    color: 'black',
+    textDecoration: 'underline',
+  },
+});
+export const BottomEllipsis = style({
+  padding: '0.2rem',
+  ':hover': {
+    cursor: 'pointer',
+    color: 'black',
+  },
+});
+export const NotRecommanded = style([
+  utils.flex,
+  utils.textAlignCenter,
+  {
+    cursor: 'pointer',
+    padding: '2px 4px',
+    borderRadius: '5px',
+    ':hover': {
+      backgroundColor: 'lightgray',
+    },
+  },
+]);
+export const BottomTitle = style([
+  utils.textOverflowEllipsis,
+  utils.overflowHidden,
+  {
+    fontWeight: 700,
+    fontSize: '2rem',
+    lineHeight: '2.4rem',
+    maxHeight: '4.8rem',
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    whiteSpace: 'normal',
+    ':hover': {
+      cursor: 'pointer',
+      textDecoration: 'underline',
+    },
+  },
+]);
+
+export const BottomCompany = style({
+  display: 'flex',
+  padding: '1.2rem 1.6rem',
+  gap: '1.6rem',
+  height: '6rem',
+  background: 'rgba(55,114,255,0.2)',
+  border: '2px solid rgba(55,114,255,0.12)',
+  borderRadius: '1.2rem',
+});
+export const CompanyName = style({
+  fontWeight: 600,
+  fontSize: vars.fontSize.small,
+});
+export const CompanyText = style({
+  fontWeight: 600,
+  fontSize: vars.fontSize.xSmall,
+  color: 'rgba(42,40,47,0.8)',
+});

--- a/src/components/cardItem/article/CardBottom.css.ts
+++ b/src/components/cardItem/article/CardBottom.css.ts
@@ -86,15 +86,17 @@ export const BottomTitle = style([
   },
 ]);
 
-export const BottomCompany = style({
-  display: 'flex',
-  padding: '1.2rem 1.6rem',
-  gap: '1.6rem',
-  height: '6rem',
-  background: 'rgba(55,114,255,0.2)',
-  border: '2px solid rgba(55,114,255,0.12)',
-  borderRadius: '1.2rem',
-});
+export const BottomCompany = style([
+  utils.flex,
+  {
+    padding: '1.2rem 1.6rem',
+    gap: '1.6rem',
+    height: '6rem',
+    background: 'rgba(55,114,255,0.2)',
+    border: '2px solid rgba(55,114,255,0.12)',
+    borderRadius: '1.2rem',
+  },
+]);
 export const CompanyName = style({
   fontWeight: 600,
   fontSize: vars.fontSize.small,

--- a/src/components/cardItem/article/CardBottom.tsx
+++ b/src/components/cardItem/article/CardBottom.tsx
@@ -3,48 +3,47 @@ import { useState } from 'react';
 import { Avatar, Divider, Icon } from '@/components/common';
 import CardModal from '@/components/cardItem/article/CardModal';
 import { Link } from 'react-router-dom';
+import { companyProps } from '.';
 
 type CardBottomProps = {
-  linkUrl: string;
+  link: string;
   creater: string;
-  date: string;
+  createdAt: string;
   title: string;
-  companyAvatar: string;
-  companyName: string;
+  recommendationCompanies: companyProps[];
 };
 
 const CardBottom = ({
-  linkUrl,
+  link,
   creater,
-  date,
+  createdAt,
   title,
-  companyAvatar,
-  companyName,
+  recommendationCompanies,
 }: CardBottomProps) => {
-  const [isModalShow, setIsModalShow] = useState<boolean>(false);
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
   const handleDotIconClick = () => {
     console.log('크리에이터 추천 안하는 api 호출');
   };
-
+  console.log(recommendationCompanies);
   return (
-    <div className={style.CardBottom}>
-      {isModalShow && <div className={style.CardBackgroundDim} />}
-      <div className={style.BottomContent}>
-        <div className={style.BottomInfo}>
-          <div style={{ display: 'flex' }}>
+    <div className={style.cardBottom}>
+      {isModalVisible && <div className={style.cardBackgroundDim} />}
+      <div className={style.bottomContent}>
+        <div className={style.bottomInfo}>
+          <div style={{ display: 'flex', gap: '0.5rem' }}>
             <Link to="/creater">
-              <span className={style.BottomInfoCreater}>{creater}</span>
+              <span className={style.bottomInfoCreater}>{creater}</span>
             </Link>
             <Divider type="vertical" />
-            <span>{date}</span>
+            <span>{createdAt}</span>
           </div>
           <CardModal
-            isOpen={isModalShow}
-            onClose={() => setIsModalShow(false)}
+            isOpen={isModalVisible}
+            onClose={() => setIsModalVisible(false)}
             style={{ top: '2.2rem', right: '1rem', zIndex: 2000 }}
           >
-            <div className={style.NotRecommanded} onClick={handleDotIconClick}>
+            <div className={style.notRecommended} onClick={handleDotIconClick}>
               <Icon
                 type="regular"
                 name="face-tired"
@@ -56,23 +55,27 @@ const CardBottom = ({
             </div>
           </CardModal>
           <div
-            onClick={() => setIsModalShow(true)}
-            className={style.BottomEllipsis}
+            onClick={() => setIsModalVisible(true)}
+            className={style.bottomEllipsis}
           >
             <Icon type="solid" name="ellipsis-vertical" />
           </div>
         </div>
-        <a href={linkUrl} target="_blank" rel="noreferrer">
-          <div className={style.BottomTitle}>{title}</div>
+        <a href={link} target="_blank" rel="noreferrer">
+          <div className={style.bottomTitle}>{title}</div>
         </a>
       </div>
-      <footer className={style.BottomCompany}>
+      <footer className={style.companyBanner}>
         <div>
-          <Avatar src={companyAvatar} shape="circle" size="small" />
+          <Avatar
+            src="https://avatars.githubusercontent.com/u/60571418?v=4"
+            shape="circle"
+            size="small"
+          />
         </div>
         <div>
-          <div className={style.CompanyName}>{companyName}</div>
-          <div className={style.CompanyText}>사람들도 관심있게 보고있어요</div>
+          <div className={style.companyName}>카카오</div>
+          <div className={style.companyText}>사람들도 관심있게 보고있어요</div>
         </div>
       </footer>
     </div>

--- a/src/components/cardItem/article/CardBottom.tsx
+++ b/src/components/cardItem/article/CardBottom.tsx
@@ -1,0 +1,82 @@
+import * as style from './CardBottom.css';
+import { useState } from 'react';
+import { Avatar, Divider, Icon } from '@/components/common';
+import CardModal from '@/components/cardItem/article/CardModal';
+import { Link } from 'react-router-dom';
+
+type CardBottomProps = {
+  linkUrl: string;
+  creater: string;
+  date: string;
+  title: string;
+  companyAvatar: string;
+  companyName: string;
+};
+
+const CardBottom = ({
+  linkUrl,
+  creater,
+  date,
+  title,
+  companyAvatar,
+  companyName,
+}: CardBottomProps) => {
+  const [isModalShow, setIsModalShow] = useState<boolean>(false);
+
+  const handleDotIconClick = () => {
+    console.log('크리에이터 추천 안하는 api 호출');
+  };
+
+  return (
+    <div className={style.CardBottom}>
+      {isModalShow && <div className={style.CardBackgroundDim} />}
+      <div className={style.BottomContent}>
+        <div className={style.BottomInfo}>
+          <div style={{ display: 'flex' }}>
+            <Link to="/creater">
+              <span className={style.BottomInfoCreater}>{creater}</span>
+            </Link>
+            <Divider type="vertical" />
+            <span>{date}</span>
+          </div>
+          <CardModal
+            isOpen={isModalShow}
+            onClose={() => setIsModalShow(false)}
+            style={{ top: '2.2rem', right: '1rem', zIndex: 2000 }}
+          >
+            <div className={style.NotRecommanded} onClick={handleDotIconClick}>
+              <Icon
+                type="regular"
+                name="face-tired"
+                size="large"
+                color="lightgray"
+                style={{ marginRight: '0.5rem' }}
+              />
+              해당 크리에이터 추천 안함
+            </div>
+          </CardModal>
+          <div
+            onClick={() => setIsModalShow(true)}
+            className={style.BottomEllipsis}
+          >
+            <Icon type="solid" name="ellipsis-vertical" />
+          </div>
+        </div>
+        <a href={linkUrl} target="_blank" rel="noreferrer">
+          <div className={style.BottomTitle}>{title}</div>
+        </a>
+      </div>
+      <footer className={style.BottomCompany}>
+        <div>
+          <Avatar src={companyAvatar} shape="circle" size="small" />
+        </div>
+        <div>
+          <div className={style.CompanyName}>{companyName}</div>
+          <div className={style.CompanyText}>사람들도 관심있게 보고있어요</div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default CardBottom;

--- a/src/components/cardItem/article/CardModal.tsx
+++ b/src/components/cardItem/article/CardModal.tsx
@@ -26,7 +26,7 @@ const CardModal = ({
     <div style={{ display: isOpen ? 'block' : 'none' }}>
       <div
         ref={ref}
-        className={style.CardModalContainer}
+        className={style.cardModalContainer}
         style={{
           ...props.style,
         }}

--- a/src/components/cardItem/article/CardModal.tsx
+++ b/src/components/cardItem/article/CardModal.tsx
@@ -1,0 +1,42 @@
+import { CSSProperties, ReactNode } from 'react';
+import * as style from './style.css';
+import useClickAway from '@/hooks/useClickAway';
+
+export type ModalProps = {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  style?: CSSProperties;
+};
+
+// 새로 ... 아이콘 모달
+const CardModal = ({
+  children,
+  isOpen = false,
+  onClose,
+  ...props
+}: ModalProps) => {
+  const ref = useClickAway((e: Event) => {
+    if (e.target instanceof HTMLElement && e.target.tagName !== 'BUTTON') {
+      onClose && onClose();
+    }
+  });
+
+  return (
+    <div style={{ display: isOpen ? 'block' : 'none' }}>
+      <div
+        ref={ref}
+        className={style.CardModalContainer}
+        style={{
+          ...props.style,
+        }}
+        onClick={onClose}
+        {...props}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default CardModal;

--- a/src/components/cardItem/article/CardTop.css.ts
+++ b/src/components/cardItem/article/CardTop.css.ts
@@ -1,31 +1,36 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import * as utils from '@/styles/utils.css';
+import { vars } from '@/styles/variants.css';
 
-export const CardTop = style({
-  position: 'relative',
-  height: '21rem',
-});
+export const cardTop = style([
+  utils.positionRelative,
+  {
+    height: '21rem',
+  },
+]);
 
-export const BookmarkWrapper = style({
-  position: 'absolute',
-  top: '1.6rem',
-  right: '1.6rem',
-  color: 'lightgray',
+export const bookmarkWrapper = style([
+  utils.positionAbsolute,
+  {
+    top: '1.6rem',
+    right: '1.6rem',
+    color: 'lightgray',
+    ':hover': {
+      cursor: 'pointer',
+      color: 'white',
+    },
+  },
+]);
+
+export const bookmarkIcon = style({
   ':hover': {
     cursor: 'pointer',
     color: 'white',
   },
 });
 
-export const BookmarkIcon = style({
-  ':hover': {
-    cursor: 'pointer',
-    color: 'white',
-  },
-});
-
-export const NumberIconWrapper = style([
+export const numberIconWrapper = style([
   utils.flex,
   utils.positionAbsolute,
   {
@@ -35,19 +40,19 @@ export const NumberIconWrapper = style([
   },
 ]);
 
-export const IconWrapper = recipe({
+export const iconWrapper = recipe({
   base: [
     utils.flexCenter,
     {
       backgroundColor: 'rgba(0,0,0,0.5)',
       borderRadius: '0.4rem',
-      padding: '4px 8px',
+      padding: '0.4rem 0.8rem',
+      gap: '0.5rem',
     },
   ],
   variants: {
     bookmark: {
       true: {
-        padding: 0,
         background: 'none',
       },
     },
@@ -55,7 +60,7 @@ export const IconWrapper = recipe({
       true: {
         cursor: 'pointer',
         ':hover': {
-          color: 'white',
+          color: vars.color.white,
         },
       },
     },

--- a/src/components/cardItem/article/CardTop.css.ts
+++ b/src/components/cardItem/article/CardTop.css.ts
@@ -1,0 +1,68 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import * as utils from '@/styles/utils.css';
+
+export const CardTop = style({
+  position: 'relative',
+  height: '21rem',
+});
+
+export const BookmarkWrapper = style({
+  position: 'absolute',
+  top: '1.6rem',
+  right: '1.6rem',
+  color: 'lightgray',
+  ':hover': {
+    cursor: 'pointer',
+    color: 'white',
+  },
+});
+
+export const BookmarkIcon = style({
+  ':hover': {
+    cursor: 'pointer',
+    color: 'white',
+  },
+});
+
+export const NumberIconWrapper = style([
+  utils.flex,
+  utils.positionAbsolute,
+  {
+    right: '1.6rem',
+    bottom: '1.6rem',
+    color: 'lightgray',
+  },
+]);
+
+export const IconWrapper = recipe({
+  base: [
+    utils.flexCenter,
+    {
+      backgroundColor: 'rgba(0,0,0,0.5)',
+      borderRadius: '0.4rem',
+      padding: '4px 8px',
+    },
+  ],
+  variants: {
+    bookmark: {
+      true: {
+        padding: 0,
+        background: 'none',
+      },
+    },
+    heart: {
+      true: {
+        cursor: 'pointer',
+        ':hover': {
+          color: 'white',
+        },
+      },
+    },
+    eyes: {
+      true: {
+        marginLeft: '0.5rem',
+      },
+    },
+  },
+});

--- a/src/components/cardItem/article/CardTop.tsx
+++ b/src/components/cardItem/article/CardTop.tsx
@@ -4,31 +4,31 @@ import { Icon } from '@/components/common';
 import ImageComponent from '@/components/common/Image';
 
 type CardTopProps = {
-  linkUrl: string;
-  imgSrc: string;
-  isBookmark: boolean;
-  isHeart: boolean;
-  likes: number;
-  views: number;
+  link: string;
+  contentImgUrl: string;
+  isBookmarked: boolean;
+  isLiked: boolean;
+  likeCount: number;
+  viewCount: number;
 };
 
 const CardTop = ({
-  linkUrl,
-  imgSrc,
-  isBookmark,
-  isHeart,
-  likes,
-  views,
+  link,
+  contentImgUrl,
+  isBookmarked,
+  isLiked,
+  likeCount,
+  viewCount,
 }: CardTopProps) => {
-  const [hasBookMark, setHasBookMark] = useState<boolean>(isBookmark);
-  const [hasHeart, setHasHeart] = useState<boolean>(isHeart);
+  const [userBookmarked, setUserBookmarked] = useState<boolean>(isBookmarked);
+  const [userLiked, setUserLiked] = useState<boolean>(isLiked);
 
   return (
-    <section className={style.CardTop}>
-      <a href={linkUrl} target="_blank" rel="noreferrer">
+    <section className={style.cardTop}>
+      <a href={link} target="_blank" rel="noreferrer">
         <ImageComponent
           defaultImage="https://via.placeholder.com/200"
-          src={imgSrc}
+          src={contentImgUrl}
           alt="카드 썸네일 이미지"
           block={true}
           width="28.8rem"
@@ -37,11 +37,11 @@ const CardTop = ({
         />
       </a>
       <div
-        className={style.BookmarkWrapper}
-        onClick={() => setHasBookMark(!hasBookMark)}
+        className={style.bookmarkWrapper}
+        onClick={() => setUserBookmarked(!userBookmarked)}
       >
-        {hasBookMark ? (
-          <div className={style.IconWrapper({ bookmark: true })}>
+        {userBookmarked ? (
+          <div className={style.iconWrapper({ bookmark: true })}>
             <Icon
               name="bookmark"
               type="solid"
@@ -50,34 +50,34 @@ const CardTop = ({
             />
           </div>
         ) : (
-          <div className={style.IconWrapper({ bookmark: true })}>
+          <div className={style.iconWrapper({ bookmark: true })}>
             <Icon name="bookmark" type="regular" size="large" color="white" />
           </div>
         )}
       </div>
       <div
-        className={style.NumberIconWrapper}
-        onClick={() => setHasHeart(!hasHeart)}
+        className={style.numberIconWrapper}
+        onClick={() => setUserLiked(!userLiked)}
       >
-        {hasHeart ? (
-          <div className={style.IconWrapper({ heart: true })}>
+        {userLiked ? (
+          <div className={style.iconWrapper({ heart: true })}>
             <Icon
               name="heart"
               type="solid"
               size="medium"
               style={{ color: 'white' }}
             />
-            <span style={{ color: 'white' }}> {likes}</span>
+            <div style={{ color: 'white' }}>{likeCount}</div>
           </div>
         ) : (
-          <div className={style.IconWrapper({ heart: true })}>
+          <div className={style.iconWrapper({ heart: true })}>
             <Icon name="heart" type="regular" size="medium" />
-            <span> {likes}</span>
+            <div>{likeCount}</div>
           </div>
         )}
-        <div className={style.IconWrapper({ eyes: true })}>
+        <div className={style.iconWrapper({ eyes: true })}>
           <Icon name="eye" type="regular" size="medium" />
-          <span> {views}</span>
+          <div>{viewCount}</div>
         </div>
       </div>
     </section>

--- a/src/components/cardItem/article/CardTop.tsx
+++ b/src/components/cardItem/article/CardTop.tsx
@@ -1,0 +1,87 @@
+import * as style from './CardTop.css';
+import { useState } from 'react';
+import { Icon } from '@/components/common';
+import ImageComponent from '@/components/common/Image';
+
+type CardTopProps = {
+  linkUrl: string;
+  imgSrc: string;
+  isBookmark: boolean;
+  isHeart: boolean;
+  likes: number;
+  views: number;
+};
+
+const CardTop = ({
+  linkUrl,
+  imgSrc,
+  isBookmark,
+  isHeart,
+  likes,
+  views,
+}: CardTopProps) => {
+  const [hasBookMark, setHasBookMark] = useState<boolean>(isBookmark);
+  const [hasHeart, setHasHeart] = useState<boolean>(isHeart);
+
+  return (
+    <section className={style.CardTop}>
+      <a href={linkUrl} target="_blank" rel="noreferrer">
+        <ImageComponent
+          defaultImage="https://via.placeholder.com/200"
+          src={imgSrc}
+          alt="카드 썸네일 이미지"
+          block={true}
+          width="28.8rem"
+          height="21rem"
+          objectFit="cover"
+        />
+      </a>
+      <div
+        className={style.BookmarkWrapper}
+        onClick={() => setHasBookMark(!hasBookMark)}
+      >
+        {hasBookMark ? (
+          <div className={style.IconWrapper({ bookmark: true })}>
+            <Icon
+              name="bookmark"
+              type="solid"
+              size="large"
+              style={{ color: 'white' }}
+            />
+          </div>
+        ) : (
+          <div className={style.IconWrapper({ bookmark: true })}>
+            <Icon name="bookmark" type="regular" size="large" color="white" />
+          </div>
+        )}
+      </div>
+      <div
+        className={style.NumberIconWrapper}
+        onClick={() => setHasHeart(!hasHeart)}
+      >
+        {hasHeart ? (
+          <div className={style.IconWrapper({ heart: true })}>
+            <Icon
+              name="heart"
+              type="solid"
+              size="medium"
+              style={{ color: 'white' }}
+            />
+            <span style={{ color: 'white' }}> {likes}</span>
+          </div>
+        ) : (
+          <div className={style.IconWrapper({ heart: true })}>
+            <Icon name="heart" type="regular" size="medium" />
+            <span> {likes}</span>
+          </div>
+        )}
+        <div className={style.IconWrapper({ eyes: true })}>
+          <Icon name="eye" type="regular" size="medium" />
+          <span> {views}</span>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CardTop;

--- a/src/components/cardItem/article/index.tsx
+++ b/src/components/cardItem/article/index.tsx
@@ -3,33 +3,40 @@ import CardTop from './CardTop';
 import CardBottom from './CardBottom';
 import * as style from './style.css';
 
-export type ArticleCardProps = {
-  linkUrl: string;
-  imgSrc: string;
-  isBookmark: boolean;
-  isHeart: boolean;
-  likes: number;
-  views: number;
-  creater: string;
-  date: string;
-  title: string;
-  companyAvatar: string;
+export type companyProps = {
+  companyLogoImgUrl: string;
   companyName: string;
+};
+
+export type ArticleCardProps = {
+  contentId: number;
+  link: string;
+  contentImgUrl: string;
+  isBookmarked: boolean;
+  isLiked: boolean;
+  likeCount: number;
+  viewCount: number;
+  creater: string;
+  createdAt: string;
+  title: string;
+  recommendationCompanies: {
+    companyAvatar: string;
+    companyName: string;
+  };
 };
 
 // props: 링크, 이미지, 북마크, 하트, 조회수, 크리에이터 이름, 날짜, 제목, 회사, 회사 아바타
 const ArticleCard = ({
-  linkUrl,
-  imgSrc,
-  isBookmark,
-  isHeart,
-  likes,
-  views,
+  link,
+  contentImgUrl,
+  isBookmarked,
+  isLiked,
+  likeCount,
+  viewCount,
   creater,
-  date,
+  createdAt,
   title,
-  companyAvatar,
-  companyName,
+  recommendationCompanies,
 }: ArticleCardProps) => {
   /*
     TODO
@@ -37,25 +44,25 @@ const ArticleCard = ({
     2. 북마크, 하트 아이콘 클릭 시, 북마크, 하트 여부에 따라 북마크, 하트 or 북마크 하트 취소
     3. Article Card 데이터 API가 오면 props가 card data 1개로 변하니 나중에 수정할 것
    */
+  console.log(recommendationCompanies);
   return (
     <Card type="article">
-      <article className={style.CardItem}>
-        <div className={style.CardContainer}>
+      <article className={style.cardItem}>
+        <div className={style.cardContainer}>
           <CardTop
-            linkUrl={linkUrl}
-            imgSrc={imgSrc}
-            isBookmark={isBookmark}
-            isHeart={isHeart}
-            likes={likes}
-            views={views}
+            link={link}
+            contentImgUrl={contentImgUrl}
+            isBookmarked={isBookmarked}
+            isLiked={isLiked}
+            likeCount={likeCount}
+            viewCount={viewCount}
           />
           <CardBottom
-            linkUrl={linkUrl}
+            link={link}
             creater={creater}
-            date={date}
+            createdAt={createdAt}
             title={title}
-            companyAvatar={companyAvatar}
-            companyName={companyName}
+            recommendationCompanies={recommendationCompanies}
           />
         </div>
       </article>

--- a/src/components/cardItem/article/index.tsx
+++ b/src/components/cardItem/article/index.tsx
@@ -3,7 +3,7 @@ import CardTop from './CardTop';
 import CardBottom from './CardBottom';
 import * as style from './style.css';
 
-export type CardProps = {
+export type ArticleCardProps = {
   linkUrl: string;
   imgSrc: string;
   isBookmark: boolean;
@@ -30,7 +30,7 @@ const ArticleCard = ({
   title,
   companyAvatar,
   companyName,
-}: CardProps) => {
+}: ArticleCardProps) => {
   /*
     TODO
     1. 아티클 카드 클릭 시 해당 링크로 이동

--- a/src/components/cardItem/article/index.tsx
+++ b/src/components/cardItem/article/index.tsx
@@ -1,0 +1,66 @@
+import { Card } from '@/components/common';
+import CardTop from './CardTop';
+import CardBottom from './CardBottom';
+import * as style from './style.css';
+
+export type CardProps = {
+  linkUrl: string;
+  imgSrc: string;
+  isBookmark: boolean;
+  isHeart: boolean;
+  likes: number;
+  views: number;
+  creater: string;
+  date: string;
+  title: string;
+  companyAvatar: string;
+  companyName: string;
+};
+
+// props: 링크, 이미지, 북마크, 하트, 조회수, 크리에이터 이름, 날짜, 제목, 회사, 회사 아바타
+const ArticleCard = ({
+  linkUrl,
+  imgSrc,
+  isBookmark,
+  isHeart,
+  likes,
+  views,
+  creater,
+  date,
+  title,
+  companyAvatar,
+  companyName,
+}: CardProps) => {
+  /*
+    TODO
+    1. 아티클 카드 클릭 시 해당 링크로 이동
+    2. 북마크, 하트 아이콘 클릭 시, 북마크, 하트 여부에 따라 북마크, 하트 or 북마크 하트 취소
+    3. Article Card 데이터 API가 오면 props가 card data 1개로 변하니 나중에 수정할 것
+   */
+  return (
+    <Card type="article">
+      <article className={style.CardItem}>
+        <div className={style.CardContainer}>
+          <CardTop
+            linkUrl={linkUrl}
+            imgSrc={imgSrc}
+            isBookmark={isBookmark}
+            isHeart={isHeart}
+            likes={likes}
+            views={views}
+          />
+          <CardBottom
+            linkUrl={linkUrl}
+            creater={creater}
+            date={date}
+            title={title}
+            companyAvatar={companyAvatar}
+            companyName={companyName}
+          />
+        </div>
+      </article>
+    </Card>
+  );
+};
+
+export default ArticleCard;

--- a/src/components/cardItem/article/style.css.ts
+++ b/src/components/cardItem/article/style.css.ts
@@ -2,11 +2,11 @@ import { style } from '@vanilla-extract/css';
 import * as utils from '@/styles/utils.css';
 import { vars } from '@/styles/variants.css';
 
-export const CardItem = style({
+export const cardItem = style({
   position: 'relative',
 });
 
-export const CardContainer = style([
+export const cardContainer = style([
   utils.flexColumn,
   utils.positionRelative,
   {
@@ -15,7 +15,7 @@ export const CardContainer = style([
   },
 ]);
 
-export const CardModalContainer = style([
+export const cardModalContainer = style([
   utils.positionAbsolute,
   utils.borderRadius,
   {

--- a/src/components/cardItem/article/style.css.ts
+++ b/src/components/cardItem/article/style.css.ts
@@ -1,0 +1,26 @@
+import { style } from '@vanilla-extract/css';
+import * as utils from '@/styles/utils.css';
+import { vars } from '@/styles/variants.css';
+
+export const CardItem = style({
+  position: 'relative',
+});
+
+export const CardContainer = style([
+  utils.flexColumn,
+  utils.positionRelative,
+  {
+    width: '28.8rem',
+    height: '41rem',
+  },
+]);
+
+export const CardModalContainer = style([
+  utils.positionAbsolute,
+  utils.borderRadius,
+  {
+    padding: '1rem',
+    backgroundColor: vars.color.white,
+    boxShadow: '0 0.3rem 0.6rem rgba(0, 0, 0, 0.2)',
+  },
+]);

--- a/src/components/cardItem/creater/index.tsx
+++ b/src/components/cardItem/creater/index.tsx
@@ -1,0 +1,71 @@
+import { Avatar, Card } from '@/components/common';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import * as style from './style.css';
+
+export type CreaterCardProps = {
+  src: string;
+  creater: string;
+  subscriber: number;
+  isSubscribe: boolean;
+  description: string;
+};
+
+const CreaterCard = ({
+  src,
+  creater,
+  subscriber,
+  isSubscribe,
+  description,
+}: CreaterCardProps) => {
+  /*
+    TODO
+    1. 크리에이터 클릭 시 특정 크리에이터로 이동하는 route 설정 
+    2. 구독 버튼 클릭 시, 구독 여부에 따라 구독 or 구독 취소
+    3. CreaterCard API가 오면 props가 card data 1개로 변하니 나중에 수정할 것
+   */
+  const [isSubscribed, setIsSubscribed] = useState(isSubscribe);
+  const handleSubscribeClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    isSubscribed ? console.log('구독 취소') : console.log('구독');
+    setIsSubscribed(!isSubscribed);
+  };
+
+  return (
+    <Card type="creater">
+      <Link to="/creater">
+        <div className={style.CreaterCardContainer}>
+          <div className={style.CreaterCardTop}>
+            <Avatar src={src} shape="circle" size="medium" />
+            <div className={style.TopInfo}>
+              <div className={style.InfoCreater}>{creater}</div>
+              <div
+                className={style.InfoSubscriber}
+              >{`구독자 ${subscriber}명`}</div>
+            </div>
+            {isSubscribed ? (
+              <button
+                type="button"
+                onClick={handleSubscribeClick}
+                className={style.TopButton({ type: isSubscribed })}
+              >
+                구독중
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleSubscribeClick}
+                className={style.TopButton({})}
+              >
+                구독
+              </button>
+            )}
+          </div>
+          <div className={style.CreaterCardBottom}>{description}</div>
+        </div>
+      </Link>
+    </Card>
+  );
+};
+
+export default CreaterCard;

--- a/src/components/cardItem/creater/index.tsx
+++ b/src/components/cardItem/creater/index.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Card } from '@/components/common';
-import { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import { Link } from 'react-router-dom';
 import * as style from './style.css';
 
@@ -25,7 +25,7 @@ const CreaterCard = ({
     3. CreaterCard API가 오면 props가 card data 1개로 변하니 나중에 수정할 것
    */
   const [isSubscribed, setIsSubscribed] = useState(isSubscribe);
-  const handleSubscribeClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleSubscribeClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     isSubscribed ? console.log('구독 취소') : console.log('구독');
     setIsSubscribed(!isSubscribed);

--- a/src/components/cardItem/creater/index.tsx
+++ b/src/components/cardItem/creater/index.tsx
@@ -34,20 +34,20 @@ const CreaterCard = ({
   return (
     <Card type="creater">
       <Link to="/creater">
-        <div className={style.CreaterCardContainer}>
-          <div className={style.CreaterCardTop}>
+        <div className={style.createrCardContainer}>
+          <div className={style.createrCardTop}>
             <Avatar src={src} shape="circle" size="medium" />
-            <div className={style.TopInfo}>
-              <div className={style.InfoCreater}>{creater}</div>
+            <div className={style.topInfo}>
+              <div className={style.infoCreater}>{creater}</div>
               <div
-                className={style.InfoSubscriber}
+                className={style.infoSubscriber}
               >{`구독자 ${subscriber}명`}</div>
             </div>
             {isSubscribed ? (
               <button
                 type="button"
                 onClick={handleSubscribeClick}
-                className={style.TopButton({ type: isSubscribed })}
+                className={style.topButton({ type: isSubscribed })}
               >
                 구독중
               </button>
@@ -55,13 +55,13 @@ const CreaterCard = ({
               <button
                 type="button"
                 onClick={handleSubscribeClick}
-                className={style.TopButton({})}
+                className={style.topButton({})}
               >
                 구독
               </button>
             )}
           </div>
-          <div className={style.CreaterCardBottom}>{description}</div>
+          <div className={style.createrCardBottom}>{description}</div>
         </div>
       </Link>
     </Card>

--- a/src/components/cardItem/creater/style.css.ts
+++ b/src/components/cardItem/creater/style.css.ts
@@ -3,18 +3,18 @@ import * as variants from '@/styles/variants.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-export const CreaterCardContainer = style([
+export const createrCardContainer = style([
   utils.flexColumn,
   { padding: '1.6rem', gap: '2.4rem' },
 ]);
 
-export const CreaterCardTop = style([utils.flexAlignCenter, { gap: '1rem' }]);
+export const createrCardTop = style([utils.flexAlignCenter, { gap: '1rem' }]);
 
-export const TopInfo = style({
+export const topInfo = style({
   flexGrow: 1,
 });
 
-export const InfoCreater = style([
+export const infoCreater = style([
   {
     fontSize: variants.vars.fontSize.medium,
     fontWeight: 600,
@@ -22,13 +22,13 @@ export const InfoCreater = style([
     letterSpacing: '-0.04rem',
   },
 ]);
-export const InfoSubscriber = style({
+export const infoSubscriber = style({
   fontWeight: 400,
   fontSize: variants.vars.fontSize.xSmall,
   color: '#A8A6AC',
 });
 
-export const TopButton = recipe({
+export const topButton = recipe({
   base: [
     utils.borderRadius,
     {
@@ -50,7 +50,7 @@ export const TopButton = recipe({
   },
 });
 
-export const CreaterCardBottom = style({
+export const createrCardBottom = style({
   fontWeight: 400,
   fontSize: variants.vars.fontSize.small,
   color: '#625F68',

--- a/src/components/cardItem/creater/style.css.ts
+++ b/src/components/cardItem/creater/style.css.ts
@@ -1,0 +1,57 @@
+import * as utils from '@/styles/utils.css';
+import * as variants from '@/styles/variants.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const CreaterCardContainer = style([
+  utils.flexColumn,
+  { padding: '1.6rem', gap: '2.4rem' },
+]);
+
+export const CreaterCardTop = style([utils.flexAlignCenter, { gap: '1rem' }]);
+
+export const TopInfo = style({
+  flexGrow: 1,
+});
+
+export const InfoCreater = style([
+  {
+    fontSize: variants.vars.fontSize.medium,
+    fontWeight: 600,
+    lineHeight: '1.9rem',
+    letterSpacing: '-0.04rem',
+  },
+]);
+export const InfoSubscriber = style({
+  fontWeight: 400,
+  fontSize: variants.vars.fontSize.xSmall,
+  color: '#A8A6AC',
+});
+
+export const TopButton = recipe({
+  base: [
+    utils.borderRadius,
+    {
+      border: '0.2rem solid #625F68',
+      padding: '1rem 1.6rem',
+      fontSize: variants.vars.fontSize.small,
+      fontWeight: 600,
+      cursor: 'pointer',
+    },
+  ],
+  variants: {
+    type: {
+      true: {
+        backgroundColor: variants.vars.color.primary,
+        color: variants.vars.color.white,
+        border: 'none',
+      },
+    },
+  },
+});
+
+export const CreaterCardBottom = style({
+  fontWeight: 400,
+  fontSize: variants.vars.fontSize.small,
+  color: '#625F68',
+});


### PR DESCRIPTION
## 💡 이슈 번호
close #43 

## 📖 작업 내용
- [x] 크리에이터 카드 UI 구현
- [x] 아티클 카드 UI 구현

## ✅ PR 포인트
- 아티클 카드 경우 이미지와 제목을 누를 시, 해당 링크로 이동하게 했습니다.
이 방법 말고 아티클 카드 전체에 링크를 걸어둬서 아이콘과 크리에이터 이름을 뺀 나머지 영역을 클릭했을 때, 링크 이동하도록 하는게 나을까요?
- 아티클 카드 경우 코드가 길어져 컴포넌트를 분리했습니다. 차라리 하나의 컴포넌트로 코드를 짜는게 나을까요?

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/60571418/221426125-44c92af6-a698-426a-9b62-dfd83f291ff2.png)
