### PR TITLE
로그인 버튼 연동

### DIFF
--- a/src/components/common/header/UserNav.tsx
+++ b/src/components/common/header/UserNav.tsx
@@ -2,13 +2,15 @@ import { useState } from 'react';
 import Button from '../button';
 import Icon from '../icon';
 
-import * as style from './style.css';
 import user from '@/assets/user.svg';
+import { isLoginModalVisibleState } from '@/stores/atoms';
+import { useSetRecoilState } from 'recoil';
+import * as style from './style.css';
 
 const UserNav = () => {
   // 임시 로그인 상태
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-
+  const setIsLoginModalVisible = useSetRecoilState(isLoginModalVisibleState);
   /*
     TODO
     1. 로그인 버튼을 눌렀을 때, 로그인 모달 띄우기 
@@ -20,7 +22,7 @@ const UserNav = () => {
         <Button
           isBold={true}
           text="로그인"
-          onClick={() => setIsLoggedIn((prevState) => !prevState)}
+          onClick={() => setIsLoginModalVisible(true)}
         />
       ) : (
         <div className={style.iconGroup}>

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,9 +1,20 @@
 import { Outlet } from 'react-router-dom';
 import Header from '@/components/common/header';
+import { LoginModal } from '@/components/modal';
+import { useRecoilState } from 'recoil';
+import { isLoginModalVisibleState } from '@/stores/atoms';
 
 const Layout = () => {
+  const [isLoginModalVisible, setIsLoginModalVisible] = useRecoilState(
+    isLoginModalVisibleState
+  );
+
   return (
     <>
+      <LoginModal
+        isOpen={isLoginModalVisible}
+        onClose={() => setIsLoginModalVisible(false)}
+      />
       <Header />
       <main>
         <Outlet />

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isLoginModalVisibleState = atom<boolean>({
+  key: 'isLoginModalVisible',
+  default: false,
+});


### PR DESCRIPTION
## 💡 이슈 번호
close #55 

## 📖 작업 내용
- [x] 로그인 모달 정의
- [x] 로그인 모달 visible atom 정의
- [x] 연동

## ✅ PR 포인트
- 로그인 모달은 전역적으로 사용될 것 같아서 layout쪽에 정의했습니다!

## 📸 스크린샷
<img width="949" alt="스크린샷 2023-02-28 오전 1 10 36" src="https://user-images.githubusercontent.com/34560965/221616996-05e63fb1-14b0-4187-b053-d0ae16b33261.png">
<img width="950" alt="스크린샷 2023-02-28 오전 1 10 45" src="https://user-images.githubusercontent.com/34560965/221617005-cb8cb3be-8ffb-47b8-a5bd-5c98563892f1.png">
