### PR TITLE
어드민 페이지 라우팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,13 +12,15 @@ import {
   CreatorDetailPage,
   MyPage,
   NotFoundPage,
-} from '@/pages/index';
+  AdminPage,
+} from '@/pages';
 import Layout from './components/layout';
 
 const router = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/" element={<Layout />}>
       <Route index element={<HomePage />} />
+      <Route path="/admin" element={<AdminPage />} />
       <Route path="/signup" element={<SignupPage />} />
       <Route path="/mypage" element={<MyPage />} />
       <Route path="/search/:keyword" element={<SearchResultPage />} />

--- a/src/__mocks__/handlers/auth.ts
+++ b/src/__mocks__/handlers/auth.ts
@@ -67,6 +67,7 @@ export const authHandlers = [
       ctx.json({
         accessToken:
           'BBBBOT42pxCMcDQrNBbEwEVUt-eAnKfUje51bNjQYt2meoaeJ_1T5kVNAW9WTmwP-vhwePbF5wn7Gr-HSNsRxmCa_U4',
+        admin: true, // true: admin, false: 일반 user
       })
     );
   }),
@@ -85,6 +86,7 @@ export const authHandlers = [
       ctx.json({
         accessToken:
           'BBBBOT42pxCMcDQrNBbEwEVUt-eAnKfUje51bNjQYt2meoaeJ_1T5kVNAW9WTmwP-vhwePbF5wn7Gr-HSNsRxmCa_U4',
+        admin: true, // true: admin, false: 일반 user
       })
     );
   }),

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -23,9 +23,12 @@ export const googleOAuth = async (code: string) => {
 type authResponse = {
   accessToken: string;
 };
+type loginResponse = {
+  admin: boolean;
+} & authResponse;
 export const login = async () => {
   try {
-    const response: authResponse = await axiosInstance.post('/members/login');
+    const response: loginResponse = await axiosInstance.post('/members/login');
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${response.accessToken}`;
     setTimeout(silentRefresh, ACCESS_TOKEN_EXPIRY_TIME - 60000);
 
@@ -73,7 +76,7 @@ export const logout = async () => {
 
 export const silentRefresh = async () => {
   try {
-    const response: authResponse = await axiosInstance.get(
+    const response: loginResponse = await axiosInstance.get(
       '/members/access-token'
     );
     axiosInstance.defaults.headers.common.Authorization = `Bearer ${response.accessToken}`;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,26 +1,13 @@
-import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import { isAuthorizedState } from '@/stores/auth';
-import { isLoginModalVisibleState } from '@/stores/modal';
 import { Header } from '@/components/common';
 import { LoginModal } from '@/components/modal';
-import { silentRefresh } from '@/api/auth';
+import { isLoginModalVisibleState } from '@/stores/modal';
+import { Outlet } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 const Layout = () => {
-  const setIsAuthorized = useSetRecoilState(isAuthorizedState);
   const [isLoginModalVisible, setIsLoginModalVisible] = useRecoilState(
     isLoginModalVisibleState
   );
-
-  useEffect(() => {
-    (async () => {
-      const response = await silentRefresh();
-      if (response) {
-        setIsAuthorized(true);
-      }
-    })();
-  }, []);
 
   return (
     <>

--- a/src/components/modal/login/index.tsx
+++ b/src/components/modal/login/index.tsx
@@ -2,7 +2,7 @@ import { googleOAuth, login } from '@/api/auth';
 import logo from '/favicon.ico';
 import googleLogo from '/assets/googleLogo.png';
 import { Avatar, Heading, Icon, Modal, Text } from '@/components/common';
-import { isAuthorizedState } from '@/stores/auth';
+import { isAdminState, isAuthorizedState } from '@/stores/auth';
 
 import * as variants from '@/styles/variants.css';
 import { useGoogleLogin } from '@react-oauth/google';
@@ -19,13 +19,19 @@ export type LoginModalProps = {
 const LoginModal = ({ isOpen, onClose }: LoginModalProps) => {
   const navigate = useNavigate();
   const setIsAuthorized = useSetRecoilState(isAuthorizedState);
+  const setIsAdmin = useSetRecoilState(isAdminState);
+
   const googleLogin = useGoogleLogin({
     onSuccess: async (res) => {
-      const response = await googleOAuth(res.code);
       onClose();
+      const response = await googleOAuth(res.code);
 
       if (response?.wasSignedUp) {
-        await login();
+        const loginResponse = await login();
+
+        if (!loginResponse) return;
+
+        setIsAdmin(loginResponse.admin);
         setIsAuthorized(true);
         navigate('/');
         return;
@@ -59,7 +65,7 @@ const LoginModal = ({ isOpen, onClose }: LoginModalProps) => {
             <Banner size={0.55} />
           </div>
         </div>
-        <button className={style.button} onClick={() => googleLogin()}>
+        <button className={style.button} onClick={googleLogin}>
           <img
             src={googleLogo}
             alt="Google logo"

--- a/src/components/modal/myInfo/index.tsx
+++ b/src/components/modal/myInfo/index.tsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { Avatar, Modal, Spinner } from '@/components/common';
 import { getMyInfo, myInfoResponse } from '@/api/member';
 import * as style from './style.css';
+import { useRecoilState } from 'recoil';
+import { isAdminState } from '@/stores/auth';
 
 const CAREER: { [key: string]: string } = {
   develop: '개발',
@@ -26,6 +28,7 @@ export type MyInfoModalProps = {
 
 const MyInfoModal = ({ isOpen, onClose, onLogout }: MyInfoModalProps) => {
   const navigate = useNavigate();
+  const isAdmin = useRecoilState(isAdminState);
 
   const { data: myInfo } = useQuery(['myInfo'], getMyInfo, {
     refetchOnWindowFocus: false,
@@ -65,6 +68,11 @@ const MyInfoModal = ({ isOpen, onClose, onLogout }: MyInfoModalProps) => {
               </li>
             );
           })}
+          {isAdmin && (
+            <li className={style.menuItem} onClick={() => navigate('/admin')}>
+              관리자 페이지
+            </li>
+          )}
         </ul>
       </Suspense>
     </Modal>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,5 @@
+const Admin = () => {
+  return <div></div>;
+};
+
+export default Admin;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,7 @@
-export { default as HomePage } from '@/pages/home';
-export { default as SignupPage } from '@/pages/signup';
-export { default as SearchResultPage } from '@/pages/searchResult';
+export { default as AdminPage } from '@/pages/admin';
 export { default as CreatorDetailPage } from '@/pages/creatorDetail';
+export { default as HomePage } from '@/pages/home';
 export { default as MyPage } from '@/pages/myPage';
 export { default as NotFoundPage } from '@/pages/notFound';
+export { default as SearchResultPage } from '@/pages/searchResult';
+export { default as SignupPage } from '@/pages/signup';

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,14 +1,40 @@
 import { silentRefresh } from '@/api/auth';
-import { atom, selector } from 'recoil';
+import { atom, DefaultValue, selector } from 'recoil';
 
-const isAuthorizedSelector = selector({
-  key: 'isAuthorizedSelector',
-  get: async () => {
-    return (await silentRefresh()) ? true : false;
+const authState = atom({
+  key: 'auth',
+  default: (async () => {
+    const response = await silentRefresh();
+
+    return {
+      isAuthorized: response?.accessToken ? true : false,
+      isAdmin: response?.admin ? true : false,
+    };
+  })(),
+});
+
+export const isAuthorizedState = selector({
+  key: 'isAuthorized',
+  get: ({ get }) => get(authState).isAuthorized,
+  set: ({ set, get }, newValue) => {
+    if (!(newValue instanceof DefaultValue)) {
+      set(authState, {
+        ...get(authState),
+        isAuthorized: newValue,
+      });
+    }
   },
 });
 
-export const isAuthorizedState = atom<boolean>({
-  key: 'isAuthorized',
-  default: isAuthorizedSelector,
+export const isAdminState = selector({
+  key: 'isAdmin',
+  get: ({ get }) => get(authState).isAdmin,
+  set: ({ set, get }, newValue) => {
+    if (!(newValue instanceof DefaultValue)) {
+      set(authState, {
+        ...get(authState),
+        isAdmin: newValue,
+      });
+    }
+  },
 });


### PR DESCRIPTION
## 💡 이슈 번호
close #120 

## 📖 작업 내용
- [x]  login response body에 admin 구별 필드 추가
- [x] admin 여부 recoil 저장
- [x] admin 여부에 따라 nav에 admin page 라우팅 버튼 추가
- [x] admin page 라우팅

## ✅ PR 포인트
- recoil에 admin 여부 저장하다가 다시 보니 silent refresh를 두 번 호출해서 로직 좀 수정했습니다.. (제일 오래 걸림 ;;)
- 관리자 페이지 이동 버튼을 nav에 둘까 하다가 반응형 구현할 때 admin non-admin 구분이 있으면 불편할 것 같아서 유저 모달에 넣었어요
- 유저 모달에 추가할 때 MENU_LIST에 넣을까 했는데 분기 처리 하는게 코드 더 길어질 것 같아서 그냥 따로 작성했는데 더 좋은 방법 있을까요?

## 📸 스크린샷
<img width="949" alt="스크린샷 2023-03-05 오전 4 55 19" src="https://user-images.githubusercontent.com/34560965/222926118-73752560-e5fd-4af9-93b4-caac36d54ea1.png">
