### PR TITLE
데일리 브리핑 페이지 차트 최솟값 설정

### DIFF
--- a/src/components/dailyBriefing/ContentsCountChart.tsx
+++ b/src/components/dailyBriefing/ContentsCountChart.tsx
@@ -32,6 +32,11 @@ export const options = {
       position: 'top' as const,
     },
   },
+  scales: {
+    y: {
+      min: 0,
+    },
+  },
 };
 
 type contentsCountChartProps = {

--- a/src/components/dailyBriefing/ContentsCountChart.tsx
+++ b/src/components/dailyBriefing/ContentsCountChart.tsx
@@ -25,20 +25,6 @@ ChartJS.register(
   Legend
 );
 
-export const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'top' as const,
-    },
-  },
-  scales: {
-    y: {
-      min: 0,
-    },
-  },
-};
-
 type contentsCountChartProps = {
   data: contentIncreaseData[];
 };
@@ -49,13 +35,39 @@ const ContentsCountChart = ({ data }: contentsCountChartProps) => {
     datasets: [
       {
         fill: true,
-        label: '누적 콘텐츠 수',
+        label: '추가된 콘텐츠 수',
         data: data.map(({ contentIncrease }) => contentIncrease),
         borderColor: 'rgb(53, 162, 235)',
         backgroundColor: 'rgba(53, 162, 235, 0.5)',
         tension: 0.5,
       },
     ],
+  };
+
+  const sortedData = data
+    .slice()
+    .sort((a, b) => b.contentIncrease - a.contentIncrease)
+    .map(({ contentIncrease }) => contentIncrease);
+
+  const max = sortedData[0];
+  const min = sortedData[data.length - 1];
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+      },
+    },
+    scales: {
+      y: {
+        min,
+        max,
+        ticks: {
+          stepSize: max - min < 10 ? 1 : undefined,
+        },
+      },
+    },
   };
 
   return (

--- a/src/components/dailyBriefing/ContentsCountChart.tsx
+++ b/src/components/dailyBriefing/ContentsCountChart.tsx
@@ -61,8 +61,8 @@ const ContentsCountChart = ({ data }: contentsCountChartProps) => {
     },
     scales: {
       y: {
-        min,
-        max,
+        min: min === 0 ? 0 : min,
+        max: max === 0 ? undefined : max,
         ticks: {
           stepSize: max - min < 10 ? 1 : undefined,
         },


### PR DESCRIPTION
## 💡 이슈 번호
close #262 

## 📖 작업 내용
- [x] y축의 최솟값 0으로 설정
- [x] y축 간격이 소수로 보이지 않도록 해결

## ✅ PR 포인트
x

## 📸 스크린샷
![image](https://user-images.githubusercontent.com/76807107/224791672-0ed859ac-c695-4452-8baa-ab9518b58d5b.png)