### PR TITLE
헤더 반응형

### DIFF
--- a/src/components/common/header/SearchBar.tsx
+++ b/src/components/common/header/SearchBar.tsx
@@ -1,10 +1,15 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { useNavigate } from 'react-router-dom';
 import { Input } from '@/components/common';
+
 import useInput from '@/hooks/useInput';
+
 import { isAuthorizedState } from '@/stores/auth';
 import { isLoginModalVisibleState } from '@/stores/modal';
+import { isSearchBarVisibleState } from '@/stores/searchBar';
 import { selectedTabState } from '@/stores/tab';
+
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
 import * as style from './style.css';
 
 export type SearchBarProps = {
@@ -17,6 +22,10 @@ const SearchBar = ({ version = 'header', onEnterPress }: SearchBarProps) => {
   const isAuthorized = useRecoilValue(isAuthorizedState);
   const setIsLoginModalVisible = useSetRecoilState(isLoginModalVisibleState);
   const setTabState = useSetRecoilState(selectedTabState);
+  const [isSearchBarVisible, setIsSearhBarVisible] = useRecoilState(
+    isSearchBarVisibleState
+  );
+
   const { value: keyword, onChange: handleKeywordChange } = useInput('');
   const inputStyle = {
     margin: version === 'header' ? '0 1rem' : '0',
@@ -33,12 +42,13 @@ const SearchBar = ({ version = 'header', onEnterPress }: SearchBarProps) => {
     }
 
     onEnterPress?.();
+    setIsSearhBarVisible(false);
     setTabState('none');
     navigate(`/search/${keyword}`);
   };
 
   return (
-    <div className={style.searchBar({ version })}>
+    <div className={style.searchBar({ version, isSearchBarVisible })}>
       <Input
         style={inputStyle}
         version={version}

--- a/src/components/common/header/SearchBar.tsx
+++ b/src/components/common/header/SearchBar.tsx
@@ -5,6 +5,7 @@ import useInput from '@/hooks/useInput';
 import { isAuthorizedState } from '@/stores/auth';
 import { isLoginModalVisibleState } from '@/stores/modal';
 import { selectedTabState } from '@/stores/tab';
+import * as style from './style.css';
 
 export type SearchBarProps = {
   version?: 'header' | 'banner';
@@ -37,15 +38,17 @@ const SearchBar = ({ version = 'header', onEnterPress }: SearchBarProps) => {
   };
 
   return (
-    <Input
-      style={inputStyle}
-      version={version}
-      type="text"
-      placeholder="키워드를 검색하세요."
-      value={keyword}
-      onChange={handleKeywordChange}
-      onEnterPress={handleEnterPress}
-    />
+    <div className={style.searchBar({ version })}>
+      <Input
+        style={inputStyle}
+        version={version}
+        type="text"
+        placeholder="키워드를 검색하세요."
+        value={keyword}
+        onChange={handleKeywordChange}
+        onEnterPress={handleEnterPress}
+      />
+    </div>
   );
 };
 

--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -1,14 +1,15 @@
-import { Tab, Text } from '@/components/common';
+import { Icon, Tab, Text, Tooltip } from '@/components/common';
 import SearchBar from './SearchBar';
 import UserNav from './userNav/index';
 
 import { lastTabState } from '@/stores/lastTab';
 import { isHomeScrolledState } from '@/stores/scroll';
+import { isSearchBarVisibleState } from '@/stores/searchBar';
 import { selectedTabState } from '@/stores/tab';
 
 import { getKeyByValue } from '@/utils/object';
 
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -28,24 +29,57 @@ const Header = () => {
   const isHomeScrolled = useRecoilValue(isHomeScrolledState);
   const [tabState, setTabState] = useRecoilState(selectedTabState);
   const setLastTabState = useSetRecoilState(lastTabState);
+  const [isSearchBarVisible, setIsSearchBarVisible] = useRecoilState(
+    isSearchBarVisibleState
+  );
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 576);
 
   const handleLogoClick = () => {
     setLastTabState('RECENT_CONTENT');
     setTabState('RECENT_CONTENT');
   };
 
+  const handleScreenResize = () => {
+    if (window.innerWidth >= 576) {
+      setIsMobile(false);
+      setIsSearchBarVisible(false);
+      return;
+    }
+
+    setIsMobile(true);
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', handleScreenResize);
+
+    return () => window.removeEventListener('reisze', handleScreenResize);
+  }, []);
+
   return (
     <header className={style.header({ isScrolled: isHomeScrolled })}>
-      <div className={style.top}>
-        <Link to="/" className={style.logo} onClick={handleLogoClick}>
-          <img src={logo} alt="hyperlink logo" />
-        </Link>
-        <span>{isHomeScrolled && <SearchBar />}</span>
-        {/* Suspense 다른 걸로 교체, 메인 페이지 배너 가운데에 생기는 버그 */}
-        <Suspense fallback={<></>}>
-          <UserNav />
-        </Suspense>
-      </div>
+      {isSearchBarVisible && isMobile && isHomeScrolled ? (
+        <div className={style.searchBarContainer}>
+          <Tooltip message="뒤로가기">
+            <Icon
+              name="arrow-left"
+              size="xLarge"
+              onClick={() => setIsSearchBarVisible(false)}
+            />
+          </Tooltip>
+          <SearchBar />
+        </div>
+      ) : (
+        <div className={style.top}>
+          <Link to="/" className={style.logo} onClick={handleLogoClick}>
+            <img src={logo} alt="hyperlink logo" />
+          </Link>
+          <span>{isHomeScrolled && <SearchBar />}</span>
+          {/* Suspense 다른 걸로 교체, 메인 페이지 배너 가운데에 생기는 버그 */}
+          <Suspense fallback={<></>}>
+            <UserNav />
+          </Suspense>
+        </div>
+      )}
       {isHomeScrolled && (
         <div className={style.bottom}>
           <Tab

--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -1,14 +1,20 @@
-import { lastTabState } from '@/stores/lastTab';
-import { isHomeScrolledState } from '@/stores/scroll';
-import { selectedTabState } from '@/stores/tab';
-import { Suspense } from 'react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { Link } from 'react-router-dom';
 import { Tab, Text } from '@/components/common';
 import SearchBar from './SearchBar';
 import UserNav from './userNav/index';
-import * as variants from '@/styles/variants.css';
+
+import { lastTabState } from '@/stores/lastTab';
+import { isHomeScrolledState } from '@/stores/scroll';
+import { selectedTabState } from '@/stores/tab';
+
+import { getKeyByValue } from '@/utils/object';
+
+import { Suspense } from 'react';
+import { Link } from 'react-router-dom';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+
 import logo from '/assets/logo.svg';
+
+import * as variants from '@/styles/variants.css';
 import * as style from './style.css';
 
 const TAB_LIST = {
@@ -23,11 +29,6 @@ const Header = () => {
   const [tabState, setTabState] = useRecoilState(selectedTabState);
   const setLastTabState = useSetRecoilState(lastTabState);
 
-  // dev pull 하면서 utils에서 가져다 사용하기
-  const getKeyByValue = (obj: { [x: string]: string }, value: string) => {
-    return Object.keys(obj).find((key) => obj[key] === value);
-  };
-
   const handleLogoClick = () => {
     setLastTabState('RECENT_CONTENT');
     setTabState('RECENT_CONTENT');
@@ -39,7 +40,7 @@ const Header = () => {
         <Link to="/" className={style.logo} onClick={handleLogoClick}>
           <img src={logo} alt="hyperlink logo" />
         </Link>
-        {isHomeScrolled ? <SearchBar /> : <span></span>}
+        <span>{isHomeScrolled && <SearchBar />}</span>
         {/* Suspense 다른 걸로 교체, 메인 페이지 배너 가운데에 생기는 버그 */}
         <Suspense fallback={<></>}>
           <UserNav />

--- a/src/components/common/header/index.tsx
+++ b/src/components/common/header/index.tsx
@@ -9,7 +9,7 @@ import { selectedTabState } from '@/stores/tab';
 
 import { getKeyByValue } from '@/utils/object';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -33,6 +33,9 @@ const Header = () => {
     isSearchBarVisibleState
   );
   const [isMobile, setIsMobile] = useState(window.innerWidth < 576);
+  const [visibility, setVisibility] = useState(
+    isSearchBarVisible && isMobile && isHomeScrolled
+  );
 
   const handleLogoClick = () => {
     setLastTabState('RECENT_CONTENT');
@@ -49,21 +52,33 @@ const Header = () => {
     setIsMobile(true);
   };
 
+  const handleSearchBarVisibility = useCallback(() => {
+    setVisibility((prevVisibility) => !prevVisibility);
+
+    const timeout = setTimeout(() => {
+      setIsSearchBarVisible((prevVisibility) => !prevVisibility);
+      clearTimeout(timeout);
+      setVisibility((prevVisibility) => !prevVisibility);
+    }, 200);
+  }, [setIsSearchBarVisible, isMobile]);
+
   useEffect(() => {
     window.addEventListener('resize', handleScreenResize);
 
-    return () => window.removeEventListener('reisze', handleScreenResize);
+    return () => {
+      window.removeEventListener('resize', handleScreenResize);
+    };
   }, []);
 
   return (
     <header className={style.header({ isScrolled: isHomeScrolled })}>
       {isSearchBarVisible && isMobile && isHomeScrolled ? (
-        <div className={style.searchBarContainer}>
-          <Tooltip message="뒤로가기">
+        <div className={style.mobileSearchBar({ visibility })}>
+          <Tooltip message="뒤로가기" position="bottom-start">
             <Icon
               name="arrow-left"
               size="xLarge"
-              onClick={() => setIsSearchBarVisible(false)}
+              onClick={handleSearchBarVisibility}
             />
           </Tooltip>
           <SearchBar />

--- a/src/components/common/header/style.css.ts
+++ b/src/components/common/header/style.css.ts
@@ -90,7 +90,19 @@ export const searchBar = recipe({
       header: [medias.small({ display: 'none' })],
       banner: {},
     },
+    isSearchBarVisible: {
+      true: {},
+    },
   },
+  compoundVariants: [
+    {
+      variants: {
+        version: 'header',
+        isSearchBarVisible: true,
+      },
+      style: [medias.small({ display: 'block' })],
+    },
+  ],
 });
 
 export const navWrapper = style([utils.positionRelative]);
@@ -103,3 +115,8 @@ export const searchIcon = recipe({
     },
   },
 });
+
+export const searchBarContainer = style([
+  utils.flexCenter,
+  { height: '4.7rem', gap: '1rem' },
+]);

--- a/src/components/common/header/style.css.ts
+++ b/src/components/common/header/style.css.ts
@@ -123,13 +123,13 @@ export const mobileSearchBar = recipe({
     {
       height: '4.7rem',
       gap: '1rem',
-      animation: `300ms ${keyframes.slideFromRightToLeft}`,
+      animation: `300ms ${keyframes.rightSlideIn}`,
     },
   ],
   variants: {
     visibility: {
       true: {
-        animation: `200ms ${keyframes.slideToRight}`,
+        animation: `200ms ${keyframes.rightSlideOut}`,
       },
     },
   },

--- a/src/components/common/header/style.css.ts
+++ b/src/components/common/header/style.css.ts
@@ -1,6 +1,7 @@
 import * as medias from '@/styles/medias.css';
 import * as utils from '@/styles/utils.css';
 import * as variants from '@/styles/variants.css';
+import * as keyframes from '@/styles/keyframes.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
@@ -116,7 +117,20 @@ export const searchIcon = recipe({
   },
 });
 
-export const searchBarContainer = style([
-  utils.flexCenter,
-  { height: '4.7rem', gap: '1rem' },
-]);
+export const mobileSearchBar = recipe({
+  base: [
+    utils.flexCenter,
+    {
+      height: '4.7rem',
+      gap: '1rem',
+      animation: `300ms ${keyframes.slideFromRightToLeft}`,
+    },
+  ],
+  variants: {
+    visibility: {
+      true: {
+        animation: `200ms ${keyframes.slideToRight}`,
+      },
+    },
+  },
+});

--- a/src/components/common/header/style.css.ts
+++ b/src/components/common/header/style.css.ts
@@ -1,12 +1,15 @@
-import { style } from '@vanilla-extract/css';
+import * as medias from '@/styles/medias.css';
 import * as utils from '@/styles/utils.css';
 import * as variants from '@/styles/variants.css';
+import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 export const header = recipe({
   base: [
     utils.fullWidth,
     utils.flexColumn,
+    medias.large({ padding: '1.2rem 6rem' }),
+    medias.medium({ padding: '1.2rem 2rem' }),
     {
       padding: '1.2rem 10rem',
     },
@@ -28,7 +31,6 @@ export const top = style([
     justifyContent: 'space-between',
     alignItems: 'center',
     height: '4.7rem',
-    minWidth: '61.5rem',
   },
 ]);
 
@@ -44,6 +46,7 @@ export const userNav = style({
 
 export const iconGroup = style([
   utils.flexAlignCenter,
+  medias.small({ gap: '1.5rem' }),
   {
     gap: '2rem',
   },
@@ -59,7 +62,7 @@ export const bottom = style([
   utils.positionRelative,
   {
     bottom: '-1.3rem',
-    paddingTop: '1rem',
+    overflowX: 'auto',
   },
 ]);
 
@@ -68,8 +71,35 @@ export const dailyBriefing = style([
   utils.spaceNoWrap,
   {
     fontSize: variants.fontSize.small,
+    selectors: {
+      [`${bottom} &`]: {
+        marginLeft: '1.5rem',
+      },
+    },
+
     ':hover': {
       color: variants.color.primary,
     },
   },
 ]);
+
+export const searchBar = recipe({
+  base: [utils.flexCenter, utils.fullWidth],
+  variants: {
+    version: {
+      header: [medias.small({ display: 'none' })],
+      banner: {},
+    },
+  },
+});
+
+export const navWrapper = style([utils.positionRelative]);
+
+export const searchIcon = recipe({
+  base: { display: 'none', margin: '0.1rem 0.6rem 0 0' },
+  variants: {
+    isScrolled: {
+      true: [medias.small({ display: 'block' })],
+    },
+  },
+});

--- a/src/components/common/header/userNav/Authorized.tsx
+++ b/src/components/common/header/userNav/Authorized.tsx
@@ -9,18 +9,20 @@ import {
   isCategoryModalVisibleState,
   isMyInfoModalVisibleState,
 } from '@/stores/modal';
+import { isHomeScrolledState } from '@/stores/scroll';
 
 import { myInfo } from '@/types/myInfo';
 
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import * as style from '../style.css';
 
 const Authorized = () => {
   const navigate = useNavigate();
   const setIsAuthorized = useSetRecoilState(isAuthorizedState);
+  const isHomeScrolled = useRecoilValue(isHomeScrolledState);
   const [isMyInfoModalVisible, setIsMyInfoModalVisible] = useRecoilState(
     isMyInfoModalVisibleState
   );
@@ -42,14 +44,22 @@ const Authorized = () => {
   };
 
   return (
-    <>
+    <div className={style.navWrapper}>
       <div className={style.iconGroup}>
+        <Tooltip message="검색">
+          <Icon
+            name="magnifying-glass"
+            size="xLarge"
+            className={style.searchIcon({ isScrolled: isHomeScrolled })}
+          />
+        </Tooltip>
         <Tooltip message="관심 카테고리 편집">
-          <div
+          <Icon
+            type="regular"
+            name="pen-to-square"
+            size="xLarge"
             onClick={() => setIsCategoryModalVisible((isVisible) => !isVisible)}
-          >
-            <Icon type="regular" name="pen-to-square" size="xLarge" />
-          </div>
+          />
         </Tooltip>
         <button className={style.userIconButton} type="button">
           {!myInfo && <Spinner />}
@@ -88,7 +98,7 @@ const Authorized = () => {
         isOpen={isCategoryModalVisible}
         onClose={() => setIsCategoryModalVisible(false)}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/header/userNav/Authorized.tsx
+++ b/src/components/common/header/userNav/Authorized.tsx
@@ -10,6 +10,7 @@ import {
   isMyInfoModalVisibleState,
 } from '@/stores/modal';
 import { isHomeScrolledState } from '@/stores/scroll';
+import { isSearchBarVisibleState } from '@/stores/searchBar';
 
 import { myInfo } from '@/types/myInfo';
 
@@ -29,6 +30,7 @@ const Authorized = () => {
   const [isCategoryModalVisible, setIsCategoryModalVisible] = useRecoilState(
     isCategoryModalVisibleState
   );
+  const setIsSearchBarVisible = useSetRecoilState(isSearchBarVisibleState);
 
   const { data: myInfo } = useQuery<myInfo>(['myInfo'], getMyInfo, {
     suspense: true,
@@ -51,6 +53,7 @@ const Authorized = () => {
             name="magnifying-glass"
             size="xLarge"
             className={style.searchIcon({ isScrolled: isHomeScrolled })}
+            onClick={() => setIsSearchBarVisible(true)}
           />
         </Tooltip>
         <Tooltip message="관심 카테고리 편집">

--- a/src/components/common/icon/index.tsx
+++ b/src/components/common/icon/index.tsx
@@ -9,6 +9,7 @@ export type IconProps = {
   color?: string;
   isPointer?: boolean;
   className?: string;
+  onClick?: () => void;
   style?: CSSProperties;
 };
 
@@ -19,6 +20,7 @@ export type IconProps = {
  * @param {string} size - Icon size(default: medium(1.4rem)) expected to be one of ['xSmall', 'small', 'medium', 'large', 'xLarge', 'huge']
  * @param {string} color - Icon color(default: #9a9a9a)
  * @param {string} className - Icon className
+ * @param {func} onClick - Icon onClick event handler
  * @returns {Icon} Font-awesome icon
  */
 
@@ -29,20 +31,18 @@ const Icon = ({
   color = variants.color.icon,
   isPointer = true,
   className = '',
+  onClick,
   ...props
 }: IconProps) => {
-  const IconStyle = {
-    cursor: isPointer ? 'pointer' : 'auto',
-  };
-
   return (
     <i
       className={`${className} fa-${type} fa-${name} ${name} ${style.icon({
         size,
+        isPointer,
       })}`}
-      style={{ color, ...IconStyle, ...props.style }}
-      {...props}
-    ></i>
+      style={{ color, ...props.style }}
+      onClick={onClick}
+    />
   );
 };
 

--- a/src/components/common/icon/style.css.ts
+++ b/src/components/common/icon/style.css.ts
@@ -11,5 +11,10 @@ export const icon = recipe({
       xLarge: { fontSize: variants.fontSize.xLarge },
       huge: { fontSize: variants.fontSize.huge },
     },
+    isPointer: {
+      true: {
+        cursor: 'pointer',
+      },
+    },
   },
 });

--- a/src/components/common/modal/style.css.ts
+++ b/src/components/common/modal/style.css.ts
@@ -1,7 +1,8 @@
-import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
+import * as keyframes from '@/styles/keyframes.css';
 import * as utils from '@/styles/utils.css';
 import * as variants from '@/styles/variants.css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 export const backgroundDimmed = style([
   utils.positionFixed,
@@ -19,6 +20,8 @@ export const modalContainer = recipe({
   base: [
     utils.borderRadius,
     {
+      animation: `300ms ${keyframes.fadeIn}`,
+      display: 'block',
       backgroundColor: variants.color.white,
       boxShadow: '0 0.3rem 0.6rem rgba(0, 0, 0, 0.2)',
     },

--- a/src/components/main/style.css.ts
+++ b/src/components/main/style.css.ts
@@ -17,6 +17,6 @@ export const toolTip = style([
   {
     bottom: '5%',
     gap: '1rem',
-    animation: `2000ms ${keyframes.slideFromUpToDown} infinite`,
+    animation: `2000ms ${keyframes.bouncing} infinite`,
   },
 ]);

--- a/src/components/modal/category/style.css.ts
+++ b/src/components/modal/category/style.css.ts
@@ -1,3 +1,4 @@
+import * as medias from '@/styles/medias.css';
 import * as utils from '@/styles/utils.css';
 import { color } from '@/styles/variants.css';
 import { style } from '@vanilla-extract/css';
@@ -7,6 +8,11 @@ export const modalContent = style([
   utils.flexJustifySpaceBetween,
   utils.positionAbsolute,
   utils.borderRadius,
+  medias.small({
+    width: '100vw',
+    minWidth: '100vw',
+    right: '-2rem',
+  }),
   {
     right: '5rem',
     gap: '4rem',

--- a/src/components/modal/category/style.css.ts
+++ b/src/components/modal/category/style.css.ts
@@ -8,8 +8,7 @@ export const modalContent = style([
   utils.positionAbsolute,
   utils.borderRadius,
   {
-    top: '2rem',
-    right: '16rem',
+    right: '5rem',
     gap: '4rem',
     padding: '3rem',
     width: '38rem',

--- a/src/components/signup/style.css.ts
+++ b/src/components/signup/style.css.ts
@@ -6,8 +6,8 @@ import { recipe } from '@vanilla-extract/recipes';
 export const wrapper = recipe({
   variants: {
     slideDirection: {
-      left: { animation: `500ms ${keyframes.slideFromLeftToRight}` },
-      right: { animation: `500ms ${keyframes.slideFromRightToLeft}` },
+      left: { animation: `500ms ${keyframes.leftSlideIn}` },
+      right: { animation: `500ms ${keyframes.rightSlideIn}` },
     },
   },
 });

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -13,9 +13,10 @@ import { throttleWheel } from '@/utils/optimization/throttle';
 import { scrollTo } from '@/utils/scroll';
 
 import { useEffect, useRef, useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import * as style from './style.css';
+import { isSearchBarVisibleState } from '@/stores/searchBar';
 
 const CATEGORIES = ['all', 'develop', 'beauty', 'finance'];
 
@@ -25,6 +26,8 @@ const Home = () => {
   const [selectedCategory, setSelectedCategory] = useRecoilState<string>(
     selectedCategoryState
   );
+  const setIsSearchBarVisible = useSetRecoilState(isSearchBarVisibleState);
+
   const tabState = useRecoilValue(selectedTabState);
   const isAuthorized = useRecoilValue(isAuthorizedState);
   const [fabVisible, setFabVisible] = useState(false);
@@ -45,6 +48,7 @@ const Home = () => {
     } else {
       if (scrollTop <= pageHeight) {
         setIsHomeScrolled(false);
+        setIsSearchBarVisible(false);
         scrollTo(ref.current, 0);
       }
     }

--- a/src/stores/searchBar.ts
+++ b/src/stores/searchBar.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isSearchBarVisibleState = atom({
+  key: 'isSearchBarVisible',
+  default: false,
+});

--- a/src/styles/keyframes.css.ts
+++ b/src/styles/keyframes.css.ts
@@ -20,3 +20,8 @@ export const fadeIn = keyframes({
   '0%': { opacity: 0 },
   '100%': { opacity: 1 },
 });
+
+export const slideToRight = keyframes({
+  '0%': { opacity: 1, transform: 'translate(0)' },
+  '100%': { opacity: 0, transform: 'translate(20rem)' },
+});

--- a/src/styles/keyframes.css.ts
+++ b/src/styles/keyframes.css.ts
@@ -1,16 +1,16 @@
 import { keyframes } from '@vanilla-extract/css';
 
-export const slideFromLeftToRight = keyframes({
+export const leftSlideIn = keyframes({
   '0%': { opacity: 0, transform: 'translateX(-20rem)' },
   '100%': { opacity: 1, transform: 'translateY(0)' },
 });
 
-export const slideFromRightToLeft = keyframes({
+export const rightSlideIn = keyframes({
   '0%': { opacity: 0, transform: 'translateX(20rem)' },
   '100%': { opacity: 1, transform: 'translateY(0)' },
 });
 
-export const slideFromUpToDown = keyframes({
+export const bouncing = keyframes({
   '0%': { transform: 'translateY(-3rem)' },
   '50%': { transform: 'translateY(0)' },
   '100%': { transform: 'translateY(-3rem)' },
@@ -21,7 +21,7 @@ export const fadeIn = keyframes({
   '100%': { opacity: 1 },
 });
 
-export const slideToRight = keyframes({
+export const rightSlideOut = keyframes({
   '0%': { opacity: 1, transform: 'translate(0)' },
   '100%': { opacity: 0, transform: 'translate(20rem)' },
 });


### PR DESCRIPTION
## 💡 이슈 번호
close #293 

## 📖 작업 내용
- [x] 헤더 반응형 구현
- [x] 모바일 뷰 검색창 및 애니메이션
- [x] 모바일 뷰 모달 리사이징 및 애니메이션

## ✅ PR 포인트
- 컴포넌트가 unmount될 때 애니메이션을 추가하려면 작성한 코드와 같이 상태 하나를 더 추가한 다음 setTimeout을 통해 클래스 변경 -> visibility 변경을 수행해야 하더군요.. 혹시 이 방법 외에 더 효율적인 방법을 알고계시나요!?
- 그리고 모달에 fadeIn 애니메이션을 추가했는데, 위에 적은 방법을 통해 (또는 더 좋은 방법을 알고 계신다면 추천해주신 방법으로) fadeOut도 적용해볼까 합니다.
- 마지막으로 모바일 뷰 일 때 내 정보 모달은 관계 없지만, 카테고리 수정 모달은 화면 밖으로 나가버려서 small media일 때 width와 right값을 고정했습니다. 이렇게 했을 때 디자인이 괜찮을지 의견 부탁드려요~~

## 📸 스크린샷
https://user-images.githubusercontent.com/34560965/229797441-86d683d7-512c-46ce-9cca-ab1c06c22d0e.mov

https://user-images.githubusercontent.com/34560965/229797522-20ca521b-03c6-471e-822d-56939a22958c.mov

<img width="373" alt="스크린샷 2023-04-04 오후 9 53 20" src="https://user-images.githubusercontent.com/34560965/229797791-d8ef54f1-f191-42f4-aa2f-9e48768d4f3f.png">

